### PR TITLE
server: make species a generic string

### DIFF
--- a/server/src/animal.ts
+++ b/server/src/animal.ts
@@ -1,20 +1,13 @@
 import { Err, Ok, Result } from "./result";
 
-export const knownSpecies = ["Dog", "Cat"] as const;
-
-// this is the same as "Dog" | "Cat"
-export type KnownSpecies = (typeof knownSpecies)[number];
-
-function isKnownSpecies(species: any): species is KnownSpecies {
-  return knownSpecies.includes(species);
-}
+export const knownSpecies = ["Dog", "Cat"];
 
 export type Animal = {
   kind: "Animal";
-  species: KnownSpecies;
+  species: string;
 };
 
-export function Animal(species: KnownSpecies): Animal {
+export function Animal(species: string): Animal {
   return {
     kind: "Animal",
     species,
@@ -28,15 +21,10 @@ function indent(body: string): string {
     .join("\n");
 }
 
-export function parseSpecies(json: any): Result<KnownSpecies, string> {
+export function parseSpecies(json: any): Result<string, string> {
   if (typeof json !== "string") {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
+    return Err(`Expected one of: ${knownSpecies.join(" | ")}, or a string
 But got: ${typeof json}`);
-  }
-
-  if (!isKnownSpecies(json)) {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
-But got: ${json}`);
   }
 
   return Ok(json);


### PR DESCRIPTION
Because the client was written to only expect Cat or Dog, the server and client become out of sync.

The client can send a request to the server with an unknown species:
> Try to send an animal with an unknown species...
> 200

But when the server contains an animal with an unknown species, the client fails to parse the animals:
> Try to get all animals with an unknown species...
> 200
> Error at animal 0:
> ---> Error parsing `.species`:
> ---> ---> Expected one of: Dog | Cat
> ---> ---> But got: Robot

As a result, this is a breaking change for the client. The client can either: 1) Loosen the types locally
2) Ignore unknown animals

Let's look at both.