### PR TITLE
client: ignore unknown species

### DIFF
--- a/client/src/animal.ts
+++ b/client/src/animal.ts
@@ -93,6 +93,10 @@ export function parseAnimals(json: any): Result<Animal[], string> {
         break;
       }
       case "Err": {
+        // Skip any animals to do with parsing species
+        if (animal.message.includes("Error parsing `.species`")) {
+          break;
+        }
         errors.push(`Error at animal ${i}:\n${indent(animal.message)}`);
         break;
       }


### PR DESCRIPTION
By ignoring unknown species on the client, we can keep all the logic the same as before while preserving type safety.

> Try to get all animals with an unknown species...
> 200
> Animals:  { kind: 'Ok', value: [] }
> Score: 0
> Count: { Cat: 0, Dog: 0 }