### PR TITLE
client: set species to string

### DIFF
--- a/client/src/animal.ts
+++ b/client/src/animal.ts
@@ -1,20 +1,13 @@
 import { Err, Ok, Result } from "./result";
 
-export const knownSpecies = ["Dog", "Cat"] as const;
-
-// this is the same as "Dog" | "Cat"
-export type KnownSpecies = (typeof knownSpecies)[number];
-
-function isKnownSpecies(species: any): species is KnownSpecies {
-  return knownSpecies.includes(species);
-}
+export const knownSpecies = ["Dog", "Cat"];
 
 export type Animal = {
   kind: "Animal";
-  species: KnownSpecies;
+  species: string;
 };
 
-export function Animal(species: KnownSpecies): Animal {
+export function Animal(species: string): Animal {
   return {
     kind: "Animal",
     species,
@@ -28,15 +21,10 @@ function indent(body: string): string {
     .join("\n");
 }
 
-export function parseSpecies(json: any): Result<KnownSpecies, string> {
+export function parseSpecies(json: any): Result<string, string> {
   if (typeof json !== "string") {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
+    return Err(`Expected one of: ${knownSpecies.join(" | ")} or a string
 But got: ${typeof json}`);
-  }
-
-  if (!isKnownSpecies(json)) {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
-But got: ${json}`);
   }
 
   return Ok(json);

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,9 +1,9 @@
-import { Animal, KnownSpecies, knownSpecies, parseAnimals } from "./animal";
+import { Animal, knownSpecies, parseAnimals } from "./animal";
 import { animalsScore, sumAnimalsOfDifferentTypes } from "./logic";
 
 const baseUrl = "http://localhost:3000";
 
-async function createValidAnimalOnServer(speices: KnownSpecies) {
+async function createValidAnimalOnServer(speices: string) {
   const animal = Animal(speices);
   await fetch(`${baseUrl}/animal`, {
     headers: {
@@ -112,7 +112,7 @@ async function main() {
 
   {
     console.log("Try to get all animals with a known species...");
-    const spieces: KnownSpecies = knownSpecies[0];
+    const spieces: string = knownSpecies[0];
     const response = await fetch(`${baseUrl}/list/${spieces}`);
     console.log(response.status);
     if (response.status === 200) {

--- a/client/src/logic.ts
+++ b/client/src/logic.ts
@@ -1,14 +1,14 @@
-import { Animal, KnownSpecies, knownSpecies } from "./animal";
+import { Animal, knownSpecies } from "./animal";
 
 export function sumAnimalsOfDifferentTypes(
   animals: Animal[]
 ): Record<string, number> {
-  const animalMap: Record<KnownSpecies, number> = {
-    Cat: 0,
-    Dog: 0,
-  };
+  const animalMap: Record<string, number> = {};
 
   for (const animal of animals) {
+    if (!(animal.species in animalMap)) {
+      animalMap[animal.species] = 0;
+    }
     animalMap[animal.species]++;
   }
 
@@ -28,12 +28,16 @@ export function onlyGetOthers(animals: Animal[]): Animal[] {
 }
 
 export function animalScore(animal: Animal): number {
+  // the developer no longer gets type hints for species and must manually catch all cases
   switch (animal.species) {
     case "Cat": {
       return -1;
     }
     case "Dog": {
       return 1;
+    }
+    default: {
+      return 0;
     }
   }
 }

--- a/client/src/logic.ts
+++ b/client/src/logic.ts
@@ -2,7 +2,7 @@ import { Animal, KnownSpecies, knownSpecies } from "./animal";
 
 export function sumAnimalsOfDifferentTypes(
   animals: Animal[]
-): Record<KnownSpecies, number> {
+): Record<string, number> {
   const animalMap: Record<KnownSpecies, number> = {
     Cat: 0,
     Dog: 0,


### PR DESCRIPTION
Now we've made species a string on the client, so parsing unknowns works:
> Try to get all animals with an unknown species...
> 200
> Animals:  { kind: 'Ok', value: [ { kind: 'Animal', species: 'Robot' } ] }
> Score: 0
> Count: { Robot: 1 }

However, the developer has now lost the type safety.