### PR TITLE
server: a separate type for known species and custom ones

### DIFF
--- a/server/src/animal.ts
+++ b/server/src/animal.ts
@@ -9,9 +9,13 @@ function isKnownSpecies(species: any): species is KnownSpecies {
   return knownSpecies.includes(species);
 }
 
+export type CustomSpecies = { kind: "CustomSpecies"; value: string };
+
+export type Species = KnownSpecies | CustomSpecies;
+
 export type Animal = {
   kind: "Animal";
-  species: KnownSpecies;
+  species: Species;
 };
 
 export function Animal(species: KnownSpecies): Animal {

--- a/server/src/animal.ts
+++ b/server/src/animal.ts
@@ -1,24 +1,53 @@
 import { Err, Ok, Result } from "./result";
 
-export const knownSpecies = ["Dog", "Cat"] as const;
+export const registeredSpecies = ["Dog", "Cat"] as const;
 
 // this is the same as "Dog" | "Cat"
-export type KnownSpecies = (typeof knownSpecies)[number];
+export type RegisteredSpecies = (typeof registeredSpecies)[number];
 
-function isKnownSpecies(species: any): species is KnownSpecies {
-  return knownSpecies.includes(species);
+function isRegisteredSpecies(species: any): species is RegisteredSpecies {
+  return registeredSpecies.includes(species);
+}
+
+export type KnownSpecies = {
+  kind: "KnownSpecies";
+  value: RegisteredSpecies;
+};
+
+function KnownSpecies(species: RegisteredSpecies): KnownSpecies {
+  return {
+    kind: "KnownSpecies",
+    value: species,
+  };
 }
 
 export type CustomSpecies = { kind: "CustomSpecies"; value: string };
 
+function CustomSpecies(species: string): CustomSpecies {
+  return {
+    kind: "CustomSpecies",
+    value: species,
+  };
+}
+
 export type Species = KnownSpecies | CustomSpecies;
+
+export function isEqualSpecies(first: Species, second: Species): boolean {
+  if (first.kind !== second.kind) return false;
+
+  return first.value === second.value;
+}
 
 export type Animal = {
   kind: "Animal";
   species: Species;
 };
 
-export function Animal(species: KnownSpecies): Animal {
+export function Animal(speciesAsAString: string): Animal {
+  let species = isRegisteredSpecies(speciesAsAString)
+    ? KnownSpecies(speciesAsAString)
+    : CustomSpecies(speciesAsAString);
+
   return {
     kind: "Animal",
     species,
@@ -32,18 +61,23 @@ function indent(body: string): string {
     .join("\n");
 }
 
-export function parseSpecies(json: any): Result<KnownSpecies, string> {
+export function parseSpecies(json: any): Result<Species, string> {
   if (typeof json !== "string") {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
+    return Err(`Expected one of: ${registeredSpecies.join(" | ")}
 But got: ${typeof json}`);
   }
 
-  if (!isKnownSpecies(json)) {
-    return Err(`Expected one of: ${knownSpecies.join(" | ")}
-But got: ${json}`);
+  if (!isRegisteredSpecies(json)) {
+    return Ok({
+      kind: "CustomSpecies",
+      value: json,
+    });
   }
 
-  return Ok(json);
+  return Ok({
+    kind: "KnownSpecies",
+    value: json,
+  });
 }
 
 export function parseAnimal(json: any): Result<Animal, string> {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,5 @@
 import express, { Response } from "express";
-import { Animal, parseAnimal, parseSpecies } from "./animal";
+import { Animal, isEqualSpecies, parseAnimal, parseSpecies } from "./animal";
 
 function sendAnimal(res: Response<any>, animal: Animal): void {
   res.send(JSON.stringify(animal));
@@ -32,7 +32,9 @@ async function main() {
         res.status(200);
         sendAnimals(
           res,
-          animals.filter((animal) => animal.species === species.value)
+          animals.filter((animal) =>
+            isEqualSpecies(animal.species, species.value)
+          )
         );
         return;
       }


### PR DESCRIPTION
### server: make species a union of known species and custom 

We've changed the type on the server to include a custom type, however TypeScript doesn't catch that this has logic implications too, so it still can't handle the error.

> Try to send an animal with an unknown species...
> 503
> Error parsing `.species`:
> ---> Expected one of: Dog | Cat
> ---> But got: Robot

This means there's a logical gap between the implementation and types. Let's fix that.

--- Commit 2

### server: add distinct types for registerd species and custom species

We've changed the types to help make sure TypeScript helps us compile.

This however breaks the client, as the internal representation changed.

> Get all saved animals...
> Error at animal 0:
> ---> Error parsing `.species`:
> ---> ---> Expected one of: Dog | Cat
> ---> ---> But got: object

> Try to get all animals with a known species...
> 200
> Error at animal 0:
> ---> Error parsing `.species`:
> ---> ---> Expected one of: Dog | Cat
> ---> ---> But got: object

This is a breaking change for the clients, but we have made the server backwards compatible.