### PR TITLE
server,client: match implementations between server and client

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,10 +1,15 @@
-import { Animal, KnownSpecies, knownSpecies, parseAnimals } from "./animal";
+import {
+  Animal,
+  KnownSpecies,
+  parseAnimals,
+  registeredSpecies,
+} from "./animal";
 import { animalsScore, sumAnimalsOfDifferentTypes } from "./logic";
 
 const baseUrl = "http://localhost:3000";
 
-async function createValidAnimalOnServer(speices: KnownSpecies) {
-  const animal = Animal(speices);
+async function createValidAnimalOnServer(species: string) {
+  const animal = Animal(species);
   await fetch(`${baseUrl}/animal`, {
     headers: {
       "Content-Type": "application/json",
@@ -34,7 +39,7 @@ async function main() {
     // Fill server with 5 random animals
     for (let i = 0; i < 5; i++) {
       await createValidAnimalOnServer(
-        knownSpecies[Math.floor(Math.random() * knownSpecies.length)]
+        registeredSpecies[Math.floor(Math.random() * registeredSpecies.length)]
       );
     }
   }
@@ -95,7 +100,7 @@ async function main() {
 
   {
     console.log("Try to send an animal with an unknown species...");
-    const animal = { kind: "Animal", species: "Robot" };
+    const animal = Animal("Robot");
     const response = await fetch(`${baseUrl}/animal`, {
       headers: {
         "Content-Type": "application/json",
@@ -112,8 +117,8 @@ async function main() {
 
   {
     console.log("Try to get all animals with a known species...");
-    const spieces: KnownSpecies = knownSpecies[0];
-    const response = await fetch(`${baseUrl}/list/${spieces}`);
+    const species: string = KnownSpecies(registeredSpecies[0]).value;
+    const response = await fetch(`${baseUrl}/list/${species}`);
     console.log(response.status);
     if (response.status === 200) {
       const animals = parseAnimals(await response.json());
@@ -138,8 +143,8 @@ async function main() {
 
   {
     console.log("Try to get all animals with an unknown species...");
-    const spieces: string = "Robot";
-    const response = await fetch(`${baseUrl}/list/${spieces}`);
+    const species: string = "Robot";
+    const response = await fetch(`${baseUrl}/list/${species}`);
     console.log(response.status);
     if (response.status === 200) {
       const animals = parseAnimals(await response.json());

--- a/client/src/logic.ts
+++ b/client/src/logic.ts
@@ -1,39 +1,54 @@
-import { Animal, KnownSpecies, knownSpecies } from "./animal";
+import { Animal } from "./animal";
 
 export function sumAnimalsOfDifferentTypes(
   animals: Animal[]
-): Record<KnownSpecies, number> {
-  const animalMap: Record<KnownSpecies, number> = {
-    Cat: 0,
-    Dog: 0,
-  };
+): Record<string, number> {
+  const animalMap: Record<string, number> = {};
 
   for (const animal of animals) {
-    animalMap[animal.species]++;
+    if (!(animal.species.value in animalMap)) {
+      animalMap[animal.species.value] = 0;
+    }
+    animalMap[animal.species.value]++;
   }
 
   return animalMap;
 }
 
 export function onlyGetCats(animals: Animal[]): Animal[] {
-  return animals.filter((animal) => animal.species === "Cat");
+  // Need to filter to known species to get type completion
+  return animals.filter(
+    (animal) =>
+      animal.species.kind === "KnownSpecies" && animal.species.value === "Cat"
+  );
 }
 
 export function onlyGetDogs(animals: Animal[]): Animal[] {
-  return animals.filter((animal) => animal.species === "Dog");
+  // Need to filter to known species to get type completion
+  return animals.filter(
+    (animal) =>
+      animal.species.kind === "KnownSpecies" && animal.species.value === "Dog"
+  );
 }
 
 export function onlyGetOthers(animals: Animal[]): Animal[] {
-  return animals.filter((animal) => !knownSpecies.includes(animal.species));
+  return animals.filter((animal) => animal.species.kind == "CustomSpecies");
 }
 
 export function animalScore(animal: Animal): number {
-  switch (animal.species) {
-    case "Cat": {
-      return -1;
+  switch (animal.species.kind) {
+    case "KnownSpecies": {
+      switch (animal.species.value) {
+        case "Cat": {
+          return -1;
+        }
+        case "Dog": {
+          return 1;
+        }
+      }
     }
-    case "Dog": {
-      return 1;
+    case "CustomSpecies": {
+      return 0;
     }
   }
 }


### PR DESCRIPTION
This implementation involves taking the parsing logic from the server and copying it to the client.

There's one slight diffrence: to support old get requests, the server parses species as either a string or an object.

All API calls work as expected.